### PR TITLE
Allow chat admin to delete channels

### DIFF
--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -93,7 +93,7 @@ local delete_channel = {
 			return false, "ERROR: Channel " .. param .. " does not exist"
 		end
 
-		if name ~= beerchat.channels[param].owner then
+		if name ~= beerchat.channels[param].owner and not minetest.check_player_privs(name, beerchat.admin_priv) then
 			return false, "ERROR: You are not the owner of channel " .. param
 		end
 

--- a/init.lua
+++ b/init.lua
@@ -9,6 +9,9 @@ beerchat = {
 	-- The main channel is the one you send messages to when no channel is specified
 	main_channel_name = minetest.settings:get("beerchat.main_channel_name") or "main",
 
+	-- Chat administrator privilege allows bypassing owner checks
+	admin_priv = minetest.settings:get("beerchat.admin_priv") or "server",
+
 	-- The default color of channels when no color is specified
 	default_channel_color = "#ffffff",
 


### PR DESCRIPTION
Adds `beerchat.admin_priv` conf key, default value is `server`.
Allows bypassing `/dc` owner check if player has that privilege.
Closes #50 