### PR TITLE
Fix # restrictions for jailed players

### DIFF
--- a/plugin/jail.lua
+++ b/plugin/jail.lua
@@ -152,6 +152,9 @@ beerchat.register_callback("on_send_on_channel", function(msg, target)
 		-- redirect #channel messages sent by jailed players toward jail channel and reconstruct full command.
 		msg.channel = beerchat.jail.channel_name
 		msg.message = "#" .. msg.channel .. " " .. msg.message
+		if not beerchat.is_player_subscribed_to_channel(target, msg.channel) then
+			return false
+		end
 	end
 end)
 

--- a/plugin/jail.lua
+++ b/plugin/jail.lua
@@ -147,11 +147,17 @@ beerchat.register_callback('before_leave', function(name, channel)
 	end
 end)
 
+beerchat.register_callback("on_send_on_channel", function(msg, target)
+	if msg.channel ~= beerchat.jail.channel_name and beerchat.is_player_jailed(msg.name) then
+		-- redirect #channel messages sent by jailed players toward jail channel and reconstruct full command.
+		msg.channel = beerchat.jail.channel_name
+		msg.message = "#" .. msg.channel .. " " .. msg.message
+	end
+end)
+
 beerchat.register_callback('before_send', function(name, message, channel)
-	local jailed = beerchat.is_player_jailed(name)
-	local is_jail_channel = channel == beerchat.jail.channel_name
-	if jailed then
-		if is_jail_channel then
+	if beerchat.is_player_jailed(name) then
+		if channel == beerchat.jail.channel_name then
 			-- override default send method to mute pings for jailed users
 			-- but allow chatting without pings on jail channel
 			minetest.chat_send_player(name, message)


### PR DESCRIPTION
Better but incomplete. There was no real channel filtering at all when `#channel message` was executed by jailed player.
After this messages by jailed players will be redirected towards jail channel if target channel is not already jail channel.

Channel subscription validation is done again because those checks were done against original target channel, without this revalidation first player in connected players might still receive message from jailed player.

Changes get automatically cached for rest of delivery chain after first actual edit and stays in effect through player loop even when returning false because target hasn't subscribed to jail channel.

`before_send` just removed unneeded variables.