### PR TITLE
Allow defining aliases for channels

### DIFF
--- a/plugin/alias.lua
+++ b/plugin/alias.lua
@@ -1,0 +1,173 @@
+--luacheck: no_unused_args
+
+beerchat.alias = {
+	priv = minetest.settings:get("beerchat.alias.priv") or "ban"
+}
+
+local channels = minetest.deserialize(beerchat.mod_storage:get("alias.channels")) or {}
+
+local function write_storage()
+	local data = minetest.serialize(channels)
+	beerchat.mod_storage:set_string("alias.channels", data)
+end
+
+local function switch_player_channel(name, alias, resolved)
+	-- Aliases can allow joining protected channel without authorization.
+	if beerchat.get_player_channel(name) == alias then
+		-- Add and move player to resolved channel
+		beerchat.set_player_channel(name, resolved)
+	else
+		-- Add player to resolved channel but keep active channel
+		beerchat.add_player_channel(name, resolved)
+	end
+end
+
+local function resolve_alias(alias)
+	if channels[alias] then
+		if beerchat.channels[channels[alias]] then
+			return channels[alias]
+		end
+		-- Cleanup invalid alias, target channel disappeared
+		channels[alias] = nil
+	end
+end
+
+local function add_alias(alias, target)
+	if alias ~= target and not channels[alias] then
+		-- Always use canonical name, resolve first to make direct links and skip chaining
+		local resolved = resolve_alias(target) or target
+		if resolved ~= alias then
+			-- Add alias if resolution seems sane
+			channels[alias] = resolved
+			write_storage()
+			for _,player in ipairs(minetest.get_connected_players()) do
+				local name = player:get_player_name()
+				if beerchat.playersChannels[name][alias] then
+					switch_player_channel(name, alias, target)
+				end
+			end
+			return true
+		end
+	end
+end
+
+local function remove_alias(alias)
+	channels[alias] = nil
+end
+
+beerchat.register_callback("before_send_on_channel", function(name, msg)
+	local resolved = resolve_alias(msg.channel)
+	if resolved then
+		msg.channel = resolved
+	end
+end, "high")
+
+beerchat.register_callback('before_switch_chan', function(name, switch)
+	local resolved = resolve_alias(switch.to)
+	if resolved then
+		if resolved == switch.from then
+			-- cannot switch back to origin
+			return false, "Channel #" .. switch.to .. " is alias for #" .. switch.from .. " and you are already there."
+		end
+		switch.to = resolved
+	end
+end, "high")
+
+--[[ HANDLERS FOR THESE EVENTS ARE WANTED BUT NOT YET FLEXIBLE ENOUGH FOR CHANNEL ALIASES:
+beerchat.register_callback('before_invite', function(name, recipient, channel) end, true)
+beerchat.register_callback('before_join', function(name, channel) end, true)
+beerchat.register_callback('before_leave', function(name, channel) end, true)
+beerchat.register_callback('before_send_me', function(name, message, channel) end, true)
+beerchat.register_callback('on_forced_join', function(name, target, channel, from_channel) end, true)
+--]]
+
+minetest.register_chatcommand("channel-alias", {
+	params = "<Alias name> [<Channel Name>]",
+	description = "Link <Alias name> channel to <Channel Name> channel. Both channels must exist."
+		.. "\nResolves alias to channel name if only first argument is given."
+		.. "\nRequires `" .. beerchat.alias.priv .. "` privileges and channel ownership for alias management.",
+	func = function(name, param)
+		local match = param:gmatch("#?([^%s,]+)")
+		local alias, channel = match(), match()
+
+		-- Check arguments, either not enough or too many arguments
+		if not alias or match() then
+			return false, "ERROR: Invalid number of arguments. Please supply the channel names."
+		end
+
+		-- Resolve alias end return results if channel argument is not supplied
+		if not channel then
+			local resolved = resolve_alias(alias)
+			if resolved then
+				return true, "Alias #" .. alias .. " resolved to #" .. resolved .. "."
+			end
+			local found = {}
+			for calias, chan in pairs(channels) do
+				if alias == chan then
+					table.insert(found, "#" .. calias)
+				end
+			end
+			if #found > 0 then
+				return true, "Resolving #" .. alias .. " failed. " ..
+					"Instead it is regular channel with following aliases:\n" .. table.concat(found, ", ")
+			end
+			return true, "Could not resolve #" .. alias .. " to channel, it does not seem to be alias."
+		end
+
+		if alias == beerchat.main_channel_name then
+			return false, "ERROR: Cannot convert main channel to alias!"
+		end
+
+		if not beerchat.channels[alias] then
+			return false, "ERROR: Channel #" .. alias .. " does not exist."
+		end
+
+		if not beerchat.channels[channel] then
+			return false, "ERROR: Channel #" .. channel .. " does not exist."
+		end
+
+		if not minetest.check_player_privs(name, beerchat.admin_priv) then
+			if not minetest.check_player_privs(name, beerchat.alias.priv) then
+				return false, "ERROR: Privilege `" .. beerchat.alias.priv .. "` is required to manage channel aliases"
+			end
+			if name ~= beerchat.channels[alias].owner then
+				return false, "ERROR: You are not the owner of alias #" .. alias
+			end
+			if name ~= beerchat.channels[channel].owner then
+				return false, "ERROR: You are not the owner of channel #" .. channel
+			end
+		end
+
+		add_alias(alias, channel)
+		return true, "Alias #" .. alias .. " created. You can now use both names to access #" .. channel .. "."
+	end
+})
+
+minetest.register_chatcommand("channel-unalias", {
+	params = "<Alias name>",
+	description = "Unlink <Alias name> channel and make it regular channel."
+		.. "\nRequires `" .. beerchat.alias.priv .. "` privileges and alias ownership for alias management.",
+	func = function(name, param)
+		local alias = param:match("^#?(%S+)$")
+		if not alias then
+			return false, "ERROR: Invalid number of arguments. Please supply the alias name."
+		end
+
+		local resolved = resolve_alias(alias)
+		if not resolved then
+			return true, "Could not resolve #" .. alias .. " to channel, it does not seem to be alias."
+		end
+
+		if not minetest.check_player_privs(name, beerchat.admin_priv) then
+			if not minetest.check_player_privs(name, beerchat.alias.priv) then
+				return false, "ERROR: Privilege `" .. beerchat.alias.priv .. "` is required to manage channel aliases"
+			end
+			if beerchat.channels[alias] and name ~= beerchat.channels[alias].owner then
+				return false, "ERROR: You are not the owner of alias #" .. alias
+			end
+		end
+
+		remove_alias(alias)
+		return true, "Alias #" .. alias .. " converted to regular channel. Delete channel if not needed anymore."
+	end
+})

--- a/plugin/hash.lua
+++ b/plugin/hash.lua
@@ -14,18 +14,18 @@ local function switch_channel(name, channel)
 		-- Skip channel switch sound because beerchat.join_channel will also play sound
 		skip_sound = true
 	end
-	if not beerchat.execute_callbacks('before_switch_chan', name,
-		beerchat.currentPlayerChannel[name], channel) then
+	local switch = { from = beerchat.get_player_channel(name), to = channel }
+	if not beerchat.execute_callbacks('before_switch_chan', name, switch) then
 		return
 	end
-	beerchat.set_player_channel(name, channel)
-	if channel == beerchat.main_channel_name then
+	beerchat.set_player_channel(name, switch.to)
+	if switch.to == beerchat.main_channel_name then
 		minetest.chat_send_player(name,
-			"Switched to channel " .. channel .. ", messages will now be sent to this channel"
+			"Switched to channel #" .. switch.to .. ", messages will now be sent to this channel"
 		)
 	else
 		minetest.chat_send_player(name,
-			"Switched to channel " .. channel .. ", messages will now be sent to this channel. "
+			"Switched to channel #" .. switch.to .. ", messages will now be sent to this channel. "
 			.. "To switch back to the main channel, type #" .. beerchat.main_channel_name
 		)
 	end

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -52,3 +52,6 @@ load_plugin("password", true)
 
 -- Adds logging and info messages for certain events
 load_plugin("event-logging", true)
+
+-- Allows linking channels through channel aliases
+load_plugin("alias", false)

--- a/plugin/jail.lua
+++ b/plugin/jail.lua
@@ -170,7 +170,7 @@ beerchat.register_callback('before_send', function(target, message, data)
 	end
 end)
 
-beerchat.register_callback('before_switch_chan', function(name, oldchannel, newchannel)
+beerchat.register_callback('before_switch_chan', function(name)
 	if beerchat.is_player_jailed(name) then
 		return false, "You are in chat-jail, no changing channels for you."
 	end

--- a/spec/fixtures/minetest.conf
+++ b/spec/fixtures/minetest.conf
@@ -1,15 +1,21 @@
-beerchat.enable_jail = true
-beerchat.jail.channel_name = jailchannel
-
+# Basic configuration
 beerchat.colorize_channels = *
+beerchat.moderator_channel_name = mod
 
-beerchat.enable_cleaner = true
+# Plugin configuration
+
+beerchat.enable_alias = true
 
 beerchat.enable_announce = true
 
 beerchat.enable_ban = true
 
-beerchat.moderator_channel_name = mod
+beerchat.enable_cleaner = true
+
+beerchat.enable_jail = true
+beerchat.jail.channel_name = jailchannel
+
+beerchat.enable_remote_mute = true
 
 # Web relay
 secure.http_mods = beerchat

--- a/spec/plugin_alias_spec.lua
+++ b/spec/plugin_alias_spec.lua
@@ -1,0 +1,130 @@
+require("mineunit")
+
+mineunit("core")
+mineunit("player")
+mineunit("server")
+
+sourcefile("init")
+
+describe("Alias", function()
+
+	local ANY = require("luassert.match")._
+
+	local SX = Player("SX", { shout = 1, ban = 1, [beerchat.admin_priv] = 1 })
+	local Sam = Player("Sam", { shout = 1 })
+	local Doe = Player("Doe", { shout = 1 })
+
+	setup(function()
+		mineunit:execute_on_joinplayer(SX)
+		mineunit:execute_on_joinplayer(Sam)
+		mineunit:execute_on_joinplayer(Doe)
+		-- Channel set 1
+		SX:send_chat_message("/cc #alias-main")
+		SX:send_chat_message("/cc #alias-main2")
+		-- Channel set 2
+		SX:send_chat_message("/cc #aliastest1")
+		SX:send_chat_message("/cc #alias-aliastest1")
+		-- Channel set 3
+		SX:send_chat_message("/cc #aliastest2")
+		SX:send_chat_message("/cc #alias-aliastest2")
+		-- Channel set 4
+		SX:send_chat_message("/cc #keepalias")
+		SX:send_chat_message("/cc #alias1-keepalias")
+		SX:send_chat_message("/cc #alias2-keepalias")
+	end)
+
+	teardown(function()
+		mineunit:execute_on_leaveplayer(Doe)
+		mineunit:execute_on_leaveplayer(Sam)
+		mineunit:execute_on_leaveplayer(SX)
+	end)
+
+	it("/channel-alias without arguments", function()
+		SX:send_chat_message("/channel-alias")
+	end)
+
+	it("create alias", function()
+		SX:send_chat_message("/channel-alias #alias-main #main")
+	end)
+
+	it("create alias invalid channel", function()
+		SX:send_chat_message("/channel-alias #channel-that-does-not-exist #main")
+		SX:send_chat_message("/channel-alias #alias-main #channel-that-does-not-exist")
+	end)
+
+	it("create alias to alias", function()
+		SX:send_chat_message("/channel-alias #alias-main2 #alias-main")
+	end)
+
+	it("resolve alias", function()
+		SX:send_chat_message("/channel-alias #alias-main")
+	end)
+
+	it("resolve alias normal channel", function()
+		SX:send_chat_message("/channel-alias #main")
+	end)
+
+	it("resolve alias invalid channel", function()
+		SX:send_chat_message("/channel-alias #channel-that-does-not-exist")
+	end)
+
+	it("remove alias", function()
+		SX:send_chat_message("/channel-unalias #alias-main")
+	end)
+
+	it("remove alias invalid channel", function()
+		SX:send_chat_message("/channel-unalias #channel-that-does-not-exist")
+		SX:send_chat_message("/channel-unalias #alias-main")
+		SX:send_chat_message("/channel-unalias #main")
+	end)
+
+	it("channel switch", function()
+		-- Prepare
+		SX:send_chat_message("/channel-alias #alias1-keepalias #keepalias")
+		SX:send_chat_message("/channel-alias #alias2-keepalias #keepalias")
+		-- Test
+		SX:send_chat_message("#keepalias")
+		assert.equal(beerchat.get_player_channel("SX"), "keepalias")
+		SX:send_chat_message("#alias1-keepalias")
+		assert.equal(beerchat.get_player_channel("SX"), "keepalias")
+		SX:send_chat_message("#alias2-keepalias")
+		assert.equal(beerchat.get_player_channel("SX"), "keepalias")
+	end)
+
+	it("delivers messages 1", function()
+		-- Prepare
+		Sam:send_chat_message("#aliastest1")
+		Doe:send_chat_message("#alias-aliastest1")
+		SX:send_chat_message("/channel-alias #alias-aliastest1 #aliastest1")
+		-- Test
+		assert.equal(beerchat.get_player_channel("Sam"), "aliastest1")
+		assert.equal(beerchat.get_player_channel("Doe"), "aliastest1")
+		spy.on(beerchat, "execute_callbacks")
+		spy.on(minetest, "chat_send_player")
+		SX:send_chat_message("#aliastest1 Test message to #aliastest1")
+		SX:send_chat_message("#alias-aliastest1 Test message to #alias-aliastest1")
+		assert.spy(beerchat.execute_callbacks).was.called_with("before_send", "SX", ANY, ANY)
+		assert.spy(beerchat.execute_callbacks).was.called_with("before_send", "Sam", ANY, ANY)
+		assert.spy(beerchat.execute_callbacks).was.called_with("before_send", "Doe", ANY, ANY)
+		assert.spy(minetest.chat_send_player).was.called(3 * 2) -- 3 players, 2 messages
+	end)
+
+	it("delivers messages 2", function()
+		-- Prepare
+		SX:send_chat_message("/channel-alias #alias-aliastest2 #aliastest2")
+		Sam:send_chat_message("#aliastest2")
+		Doe:send_chat_message("#alias-aliastest2")
+		-- Test
+		assert.equal(beerchat.get_player_channel("Sam"), "aliastest2")
+		assert.equal(beerchat.get_player_channel("Doe"), "aliastest2")
+		spy.on(beerchat, "execute_callbacks")
+		spy.on(minetest, "chat_send_player")
+		SX:send_chat_message("#aliastest2 Test message to #aliastest2")
+		SX:send_chat_message("#alias-aliastest2 Test message to #alias-aliastest2")
+		assert.spy(beerchat.execute_callbacks).was.called_with("before_send", "SX", ANY, ANY)
+		assert.spy(beerchat.execute_callbacks).was.called_with("before_send", "Sam", ANY, ANY)
+		assert.spy(beerchat.execute_callbacks).was.called_with("before_send", "Doe", ANY, ANY)
+		assert.spy(minetest.chat_send_player).was.called(3 * 2) -- 3 players, 2 messages
+	end)
+
+end)

--- a/spec/plugin_hash_spec.lua
+++ b/spec/plugin_hash_spec.lua
@@ -1,0 +1,78 @@
+require("mineunit")
+
+mineunit("core")
+mineunit("player")
+mineunit("server")
+
+sourcefile("init")
+
+describe("Hash", function()
+
+	local ANY = require("luassert.match")._
+	assert:register("matcher", "has_channel", function(_, args)
+		return function(msg)
+			return type(msg) == "table" and msg.channel == args[1]
+		end
+	end)
+	local CHANNEL = require("luassert.match").has_channel
+
+	local SX = Player("SX", { shout = 1 })
+
+	setup(function()
+		mineunit:execute_on_joinplayer(SX)
+		-- Test channels
+		beerchat.channels["hash-test1"] = { owner = "beerholder", color = beerchat.default_channel_color }
+		beerchat.channels["hash-test2"] = { owner = "beerholder", color = beerchat.default_channel_color }
+	end)
+
+	before_each(function()
+		beerchat.set_player_channel("SX", "main")
+	end)
+
+	teardown(function()
+		mineunit:execute_on_leaveplayer(SX)
+	end)
+
+	it("handles current channel", function()
+		assert.equal(beerchat.get_player_channel("SX"), "main")
+		SX:send_chat_message("#main")
+		assert.equal(beerchat.get_player_channel("SX"), "main")
+	end)
+
+	it("handles missing channel", function()
+		assert.equal(beerchat.get_player_channel("SX"), "main")
+		SX:send_chat_message("#channel-does-not-exist")
+		assert.equal(beerchat.get_player_channel("SX"), "main")
+	end)
+
+	it("joins and switches channel", function()
+		local expected_switch = { from = "main", to = "hash-test1" }
+		assert.equal(beerchat.get_player_channel("SX"), "main")
+		spy.on(beerchat, "execute_callbacks")
+		SX:send_chat_message("#hash-test1")
+		assert.spy(beerchat.execute_callbacks).not_called_with("on_send_on_channel", ANY, ANY)
+		assert.spy(beerchat.execute_callbacks).called_with("before_switch_chan", "SX", expected_switch)
+		assert.equal(beerchat.get_player_channel("SX"), "hash-test1")
+	end)
+
+	it("sends message without switching channel", function()
+		assert.equal(beerchat.get_player_channel("SX"), "main")
+		spy.on(beerchat, "execute_callbacks")
+		SX:send_chat_message("#hash-test1 Test message")
+		assert.spy(beerchat.execute_callbacks).not_called_with("before_switch_chan", ANY, ANY)
+		assert.spy(beerchat.execute_callbacks).called_with("on_send_on_channel", "SX", CHANNEL("hash-test1"), "SX")
+		assert.equal(beerchat.get_player_channel("SX"), "main")
+	end)
+
+	it("requires joining before sending messages", function()
+		assert.equal(beerchat.get_player_channel("SX"), "main")
+		spy.on(beerchat, "execute_callbacks")
+		SX:send_chat_message("#hash-test2 Test message")
+		assert.spy(beerchat.execute_callbacks).not_called_with("before_switch_chan", ANY, ANY)
+		assert.spy(beerchat.execute_callbacks).not_called_with("before_join", ANY, ANY)
+		assert.spy(beerchat.execute_callbacks).not_called_with("before_send_on_channel", ANY, ANY)
+		assert.spy(beerchat.execute_callbacks).not_called_with("on_send_on_channel", ANY, ANY, ANY)
+		assert.equal(beerchat.get_player_channel("SX"), "main")
+	end)
+
+end)

--- a/spec/plugin_whisper_spec.lua
+++ b/spec/plugin_whisper_spec.lua
@@ -101,7 +101,7 @@ describe("Whisper", function()
 
 		-- Verify that message was handled correctly
 		assert.spy(beerchat.send_on_channel).was_not.called()
-		assert.spy(beerchat.execute_callbacks).was.called_with("before_switch_chan", "SX", m._, m._)
+		assert.spy(beerchat.execute_callbacks).was.called_with("before_switch_chan", "SX", m._)
 	end)
 
 	it("pm in whisper mode", function()


### PR DESCRIPTION
Closes #56

Adds commands:
* `/channel-alias #alias [#target]` to link channels.
* `/channel-unalias #alias` to remove channel link.

Utilizes normal beerchat channels so that alias is also normal channel but messages sent there will be redirected toward target channel and everyone who has joined alias will also be target channel member.

No idea how well it works, never tested.
Preview is built on top of #85 and should be rebased after #85 gets merged.