### PR TITLE
Custom message formatting for jailed players

### DIFF
--- a/common.lua
+++ b/common.lua
@@ -83,10 +83,12 @@ beerchat.is_player_subscribed_to_channel = function(name, channel)
 end
 
 beerchat.send_message = function(name, message, data)
-	if type(data) == "table" and beerchat.execute_callbacks('before_send', name, message, data) then
-		minetest.chat_send_player(name, data.message)
-	elseif beerchat.execute_callbacks('before_send', name, message) then
-		minetest.chat_send_player(name, message)
+	if beerchat.execute_callbacks('before_send', name, message or data.message, data) then
+		if type(data) == "table" then
+			minetest.chat_send_player(name, data.message or message)
+		else
+			minetest.chat_send_player(name, message)
+		end
 	end
 	--[[ TODO: read player settings for channel sounds, also move this from core to some sound effect extension.
 	if beerchat.enable_sounds and channel ~= beerchat.main_channel_name then

--- a/format_message.lua
+++ b/format_message.lua
@@ -1,14 +1,16 @@
 
 local function format_string(s, tab)
-  return (s:gsub('($%b{})', function(w) return tab[w:sub(3, -2)] or w end))
+	return (s:gsub('($%b{})', function(w) return tab[w:sub(3, -2)] or w end))
 end
 
-local function colorize_target_name(s, target)
-  if not target or not s then
-    return s
-  end
+-- Expose format_string to public
+beerchat.format_string = format_string
 
-  return s:gsub(target, minetest.colorize("#ff0000", target))
+local function colorize_target_name(s, target)
+	if not target or not s then
+		return s
+	end
+	return s:gsub(target, minetest.colorize("#ff0000", target))
 end
 
 beerchat.format_message = function(s, tab)

--- a/message.lua
+++ b/message.lua
@@ -40,7 +40,6 @@ beerchat.send_on_channel = function(msg, ...)
 	-- Execute registered event handlers, abort if told to do so
 	if beerchat.execute_callbacks('before_send_on_channel', msg.name, msg) then
 		-- Log and deliver message to both local and remote platforms
-		minetest.log("action", "[beerchat] CHAT #" .. msg.channel .. " <" .. msg.name .. "> " .. msg.message)
 		beerchat.on_channel_message(msg.channel, msg.name, msg.message)
 		send_on_local_channel(msg)
 	end

--- a/plugin/event-logging.lua
+++ b/plugin/event-logging.lua
@@ -19,3 +19,7 @@ beerchat.register_callback('on_forced_join', function(name, target, channel, fro
 	-- inform admin
 	minetest.log("action", "CHAT " .. move_msg)
 end)
+
+beerchat.register_callback('before_send_on_channel', function(_, msg)
+	minetest.log("action", "[beerchat] CHAT #" .. msg.channel .. " <" .. msg.name .. "> " .. msg.message)
+end)

--- a/plugin/me.lua
+++ b/plugin/me.lua
@@ -31,16 +31,15 @@ minetest.register_chatcommand("me", {
 				-- Checking if the target is in this channel
 				if beerchat.is_player_subscribed_to_channel(target, channel) then
 					if not beerchat.has_player_muted_player(target, name) then
-						beerchat.send_message(
-							target,
-							beerchat.format_message(me_message_string, {
+						beerchat.send_message(target, nil, {
+							name = name,
+							message = beerchat.format_message(me_message_string, {
 								to_player = target,
 								channel_name = channel,
 								from_player = name,
 								message = msg
-							}),
-							channel
-						)
+							})
+						})
 					end
 				end
 			end

--- a/plugin/whisper.lua
+++ b/plugin/whisper.lua
@@ -33,17 +33,16 @@ local function whisper(pos, radius, name, msg)
 					successful = true
 				end
 				-- deliver message
-				beerchat.send_message(
-					target,
-					beerchat.format_message(whisper_string, {
+				beerchat.send_message(target, nil, {
+					name = name,
+					message = beerchat.format_message(whisper_string, {
 						from_player = name,
 						to_player = target,
 						message = msg,
 						color = whisper_color,
 						colorize_all = true
-					}),
-					""
-				)
+					})
+				})
 			end
 		end
 	end

--- a/spec/plugin_jail_spec.lua
+++ b/spec/plugin_jail_spec.lua
@@ -104,3 +104,32 @@ describe("chat_unjail command", function()
 	end)
 
 end)
+
+describe("jail behavior", function()
+
+	setup(do_setup)
+	teardown(do_teardown)
+	before_each(do_before_each)
+	after_each(do_after_each)
+
+	it("allows non jailed chatting", function()
+		SX:send_chat_message("#jailchannel")
+		XX:send_chat_message("#jailchannel")
+		spy.on(minetest, "chat_send_player")
+		SX:send_chat_message("Not jailed, jail channel test message 1")
+		SX:send_chat_message("#jailchannel Not jailed, jail channel test message 2")
+		-- check that 4 message were delivered, 2 for each player
+		assert.spy(minetest.chat_send_player).was.called(4)
+	end)
+
+	it("allows jailed chatting", function()
+		SX:send_chat_message("/chat_jail XX")
+		SX:send_chat_message("#jailchannel")
+		spy.on(minetest, "chat_send_player")
+		XX:send_chat_message("Jailed, jail channel test message 1")
+		XX:send_chat_message("#jailchannel Jailed, jail channel test message 2")
+		-- check that 4 message were delivered, 2 for each player
+		assert.spy(minetest.chat_send_player).was.called(4)
+	end)
+
+end)


### PR DESCRIPTION
First of all fixes #90 where formatting was dropped completely.

But wont restore generic formatting but instead adds jail channel specific formatting for jailed players, players who are not jailed will still utilize generic / global formatting.

Makes format_string function public, this was local before but it seems it could be useful to allow special formatting through plugins. Even for this one case I think it is better to just expose that function to public, it allows handling beerchat format strings without having to know about internals.

Then also this is not only way, generic formatting could still be used. I just think it is worse for jail and this gave good opportunity to change that.

Beg to differ? Well, there's text box where beggars can go beg down there ⬇️