### PR TITLE
Rework mute and pm

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -3,8 +3,7 @@ name: luacheck
 on: [push, pull_request]
 
 jobs:
-  build:
-
+  luacheck:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/mineunit.yml
+++ b/.github/workflows/mineunit.yml
@@ -4,8 +4,20 @@ name: mineunit
 on: [push, pull_request]
 
 jobs:
-  build:
+  mineunit:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: mt-mods/mineunit-actions@v0.2
+    - id: mineunit
+      uses: mt-mods/mineunit-actions@master
+      with:
+        badge-label: Test coverage
+
+    - uses: RubbaBoy/BYOB@v1.3.0
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+      with:
+        NAME: "${{ steps.mineunit.outputs.badge-name }}"
+        LABEL: "${{ steps.mineunit.outputs.badge-label }}"
+        STATUS: "${{ steps.mineunit.outputs.badge-status }}"
+        COLOR: "${{ steps.mineunit.outputs.badge-color }}"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Chat mod for minetest
 
 (heavily modified version of the "original" beerchat mod: https://github.com/evrooije/beerchat.git)
 
-![](https://github.com/minetest-beerchat/beerchat/workflows/luacheck/badge.svg)
-![](https://github.com/minetest-beerchat/beerchat/workflows/mineunit/badge.svg)
+![](https://github.com/mt-mods/beerchat/workflows/luacheck/badge.svg)
+![](https://github.com/mt-mods/beerchat/workflows/mineunit/badge.svg)
+![](https://byob.yarr.is/mt-mods/beerchat/coverage)
 
 # Overview
 

--- a/chatcommands.lua
+++ b/chatcommands.lua
@@ -286,81 +286,6 @@ local invite_channel = {
 	end
 }
 
-local mute_player = {
-	params = "<Player Name>",
-	description = "Mute a player. After muting a player, you will no longer see chat "
-		.. "messages of this user, regardless of what channel his user sends messages to.",
-	func = function(name, param)
-
-		if not beerchat.execute_callbacks('before_mute', name, param) then
-			return false
-		end
-
-		if not param or param == "" then
-			return false, "ERROR: Invalid number of arguments. Please supply the name "
-				.. "of the user to mute."
-		end
-
-		if beerchat.has_player_muted_player(name, param) then
-			minetest.chat_send_player(name, "Player " .. param .. " is already muted.")
-		else
-			minetest.get_player_by_name(name):get_meta():set_string(
-				"beerchat:muted:" .. param, "true")
-			minetest.chat_send_player(name, "Muted player " .. param .. ".")
-		end
-		return true
-	end
-}
-
-local unmute_player = {
-	params = "<Player Name>",
-	description = "Unmute a player. After unmuting a player, you will again see chat "
-		.. "messages of this user",
-	func = function(name, param)
-		if not param or param == "" then
-			return false, "ERROR: Invalid number of arguments. Please supply the "
-				.. "name of the user to mute."
-		end
-
-		if beerchat.has_player_muted_player(name, param) then
-			minetest.get_player_by_name(name):get_meta():set_string(
-				"beerchat:muted:" .. param, "")
-			minetest.chat_send_player(name, "Unmuted player " .. param .. ".")
-		else
-			minetest.chat_send_player(name, "Player " .. param .. " was not muted.")
-		end
-		return true
-	end
-}
-
-local list_muted = {
-	params = "",
-	description = "Show list of muted players.",
-	func = function(name)
-
-		local player = minetest.get_player_by_name(name)
-		local tMeta = player:get_meta():to_table()
-
-		if nil == tMeta or nil == tMeta.fields then return false end
-
-		local sOut = ""
-		for sKey, _ in pairs(tMeta.fields) do
-			if "beerchat:muted:" == sKey:sub(1, 15) then
-				sOut = sOut .. sKey:sub(16, -1) .. ', '
-			end
-		end
-
-		if 0 == #sOut then
-			sOut = "You have not muted any players."
-		else
-			-- remove trailing comma and space
-			sOut = sOut:sub(1, -3)
-		end
-		minetest.chat_send_player(name, sOut)
-		return true
-	end
-}
-
 minetest.register_chatcommand("cc", create_channel)
 minetest.register_chatcommand("create_channel", create_channel)
 minetest.register_chatcommand("dc", delete_channel)
@@ -375,9 +300,3 @@ minetest.register_chatcommand("lc", leave_channel)
 minetest.register_chatcommand("leave_channel", leave_channel)
 minetest.register_chatcommand("ic", invite_channel)
 minetest.register_chatcommand("invite_channel", invite_channel)
-
-minetest.register_chatcommand("mute", mute_player)
-minetest.register_chatcommand("ignore", mute_player)
-minetest.register_chatcommand("unmute", unmute_player)
-minetest.register_chatcommand("unignore", unmute_player)
-minetest.register_chatcommand("list_muted", list_muted)

--- a/common.lua
+++ b/common.lua
@@ -60,21 +60,12 @@ beerchat.join_channel = function(name, channel, set_default)
 	return true
 end
 
+beerchat.allow_private_message = function(name, target)
+	return beerchat.execute_callbacks("before_send_pm", name, "", target)
+end
+
 beerchat.has_player_muted_player = function(name, other_name)
-	local cb_result = beerchat.execute_callbacks('before_check_muted', name, other_name)
-	if cb_result ~= nil then
-		return cb_result
-	end
-
-	local player = minetest.get_player_by_name(name)
-	-- check jic method is used incorrectly
-	if not player then
-		return true
-	end
-
-	local key = "beerchat:muted:" .. other_name
-	local meta = player:get_meta()
-	return "true" == meta:get_string(key)
+	return not beerchat.execute_callbacks("before_check_muted", name, other_name)
 end
 
 beerchat.is_player_subscribed_to_channel = function(name, channel)

--- a/hooks.lua
+++ b/hooks.lua
@@ -70,10 +70,6 @@ beerchat.execute_callbacks = function(trigger, ...)
 			return result
 		end
 	end
-	if trigger == 'before_check_muted' then
-		-- requires special handling, might need to create another callback registration for special methods
-		return nil
-	end
 	return true
 end
 

--- a/plugin/hash.lua
+++ b/plugin/hash.lua
@@ -40,10 +40,9 @@ local function switch_channel(name, channel)
 	end
 end
 
-beerchat.register_callback("on_send_on_channel", function(name, msg, target)
-	-- Check subscriptions and muting, abort if not subscribed or target has muted sender.
-	if not beerchat.is_player_subscribed_to_channel(target, msg.channel)
-		or beerchat.has_player_muted_player(target, name) then
+beerchat.register_callback("on_send_on_channel", function(_, msg, target)
+	-- Check subscriptions, cancel if target has not subscribed to channel.
+	if not beerchat.is_player_subscribed_to_channel(target, msg.channel) then
 		return false
 	end
 end)

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -11,6 +11,9 @@ local function load_plugin(name, enable_default)
 	end
 end
 
+-- Allows players to mute other players
+load_plugin("mute", true)
+
 -- Allows sending special formatted "/me message here" messages to channel
 load_plugin("me", true)
 

--- a/plugin/mute.lua
+++ b/plugin/mute.lua
@@ -1,0 +1,112 @@
+
+local is_muted = function(name, target)
+	local player = minetest.get_player_by_name(name)
+	if player then
+		local meta = player:get_meta()
+		return meta:get("beerchat:muted:" .. target) == "true"
+	end
+	return true
+end
+
+-- Events
+
+beerchat.register_callback("before_send_pm", function(name, _, target)
+	if is_muted(name, target) then
+		return false
+	end
+end)
+
+beerchat.register_callback("before_check_muted", function(name, target)
+	if is_muted(name, target) then
+		return false
+	end
+end)
+
+beerchat.register_callback("on_send_on_channel", function(name, _, target)
+	if is_muted(name, target) then
+		return false
+	end
+end)
+
+-- Chat commands
+
+local mute_player = {
+	params = "<Player Name>",
+	description = "Mute a player. After muting a player, you will no longer see chat "
+		.. "messages of this user, regardless of what channel his user sends messages to.",
+	func = function(name, param)
+
+		if not beerchat.execute_callbacks("before_mute", name, param) then
+			return false
+		end
+
+		if not param or param == "" then
+			return false, "ERROR: Invalid number of arguments. Please supply the name "
+				.. "of the user to mute."
+		end
+
+		if beerchat.has_player_muted_player(name, param) then
+			minetest.chat_send_player(name, "Player " .. param .. " is already muted.")
+		else
+			minetest.get_player_by_name(name):get_meta():set_string(
+				"beerchat:muted:" .. param, "true")
+			minetest.chat_send_player(name, "Muted player " .. param .. ".")
+		end
+		return true
+	end
+}
+
+local unmute_player = {
+	params = "<Player Name>",
+	description = "Unmute a player. After unmuting a player, you will again see chat "
+		.. "messages of this user",
+	func = function(name, param)
+		if not param or param == "" then
+			return false, "ERROR: Invalid number of arguments. Please supply the "
+				.. "name of the user to mute."
+		end
+
+		if beerchat.has_player_muted_player(name, param) then
+			minetest.get_player_by_name(name):get_meta():set_string(
+				"beerchat:muted:" .. param, "")
+			minetest.chat_send_player(name, "Unmuted player " .. param .. ".")
+		else
+			minetest.chat_send_player(name, "Player " .. param .. " was not muted.")
+		end
+		return true
+	end
+}
+
+local list_muted = {
+	params = "",
+	description = "Show list of muted players.",
+	func = function(name)
+
+		local player = minetest.get_player_by_name(name)
+		local tMeta = player:get_meta():to_table()
+
+		if nil == tMeta or nil == tMeta.fields then return false end
+
+		local sOut = ""
+		for sKey, _ in pairs(tMeta.fields) do
+			if "beerchat:muted:" == sKey:sub(1, 15) then
+				sOut = sOut .. sKey:sub(16, -1) .. ", "
+			end
+		end
+
+		if 0 == #sOut then
+			sOut = "You have not muted any players."
+		else
+			-- remove trailing comma and space
+			sOut = sOut:sub(1, -3)
+		end
+		minetest.chat_send_player(name, sOut)
+		return true
+	end
+}
+
+minetest.register_chatcommand("mute", mute_player)
+minetest.register_chatcommand("ignore", mute_player)
+minetest.register_chatcommand("unmute", unmute_player)
+minetest.register_chatcommand("unignore", unmute_player)
+minetest.register_chatcommand("list_muted", list_muted)

--- a/plugin/pm.lua
+++ b/plugin/pm.lua
@@ -2,8 +2,8 @@ local private_message_string = "[PM] from (${from_player}) ${message}"
 local self_message_string = "(${from_player} utters to him/ herself) ${message}"
 local private_message_sent_string = "[PM] sent to @(${to_player}) ${message}"
 
-local private_message_sound = "beerchat_chime"		-- Sound when you receive a private message
-local self_message_sound = "beerchat_utter"			-- Sound when you send a private message to yourself
+local private_message_sound = "beerchat_chime" -- Sound when you receive a private message
+local self_message_sound = "beerchat_utter" -- Sound when you send a private message to yourself
 
 -- @ chat a.k.a. at chat/ PM chat code, to PM players using @player1 only you can read this player1!!
 local atchat_lastrecv = {}
@@ -14,83 +14,81 @@ minetest.register_on_leaveplayer(function(player)
 	atchat_lastrecv[name] = nil
 end)
 
+local send_pm = function(name, msg, target, ping)
+	-- Checking if the target exists
+	if not minetest.get_player_by_name(target) then
+		minetest.chat_send_player(name, ""..target.." is not online")
+	elseif target ~= name then
+		if beerchat.execute_callbacks("before_send_pm", name, msg, target) then
+			-- Sending the message
+			minetest.chat_send_player(
+				target,
+				beerchat.format_message(
+					private_message_string, {
+						from_player = name,
+						to_player = target,
+						message = msg
+					}
+				)
+			)
+			if ping and beerchat.enable_sounds then
+				minetest.sound_play(private_message_sound, { to_player = target, gain = beerchat.sounds_default_gain } )
+			end
+			return true
+		end
+	else
+		minetest.chat_send_player(
+			target,
+			beerchat.format_message(
+				self_message_string, {
+					from_player = name,
+					to_player = target,
+					message = msg
+				}
+			)
+		)
+		if beerchat.enable_sounds then
+			minetest.sound_play(self_message_sound, { to_player = target, gain = beerchat.sounds_default_gain } )
+		end
+		return true
+	end
+	return false
+end
+
+local send_pm_all = function(name, msg, targets)
+	local sent = {}
+	for target in targets do
+		if send_pm(name, msg, target, true) then
+			table.insert(sent, target)
+		end
+	end
+	-- Register the chat in the target persons last spoken to table
+	if #sent > 0 then
+		atchat_lastrecv[name] = sent
+		minetest.chat_send_player(
+			name,
+			beerchat.format_message(
+				private_message_sent_string, {
+					to_player = table.concat(sent, ","),
+					message = msg
+				}
+			)
+		)
+	end
+end
+
 beerchat.register_on_chat_message(function(name, message)
 	minetest.log("action", "CHAT " .. name .. ": " .. message)
-
 	local players, msg = string.match(message, "^@([^%s:]*)[%s:](.*)")
 	if players and msg then
 		if msg == "" then
 			minetest.chat_send_player(name, "Please enter the private message you would like to send")
 		else
-			if not beerchat.execute_callbacks('before_send_pm', name, msg, players) then
-				return false
-			end
-			if players == "" then--reply
-				-- We need to get the target
-				players = atchat_lastrecv[name]
-			end
-			if players and players ~= "" then
-				local atleastonesent = false
-				local successplayers = ""
-				for target in string.gmatch(","..players..",", ",([^,]+),") do
-					-- Checking if the target exists
-					if not minetest.get_player_by_name(target) then
-						minetest.chat_send_player(name, ""..target.." is not online")
-					else
-						if not beerchat.has_player_muted_player(target, name) then
-							if target ~= name then
-								-- Sending the message
-								minetest.chat_send_player(
-									target,
-									beerchat.format_message(
-										private_message_string, {
-											from_player = name,
-											to_player = target,
-											message = msg
-										}
-									)
-								)
-
-								if beerchat.enable_sounds then
-									minetest.sound_play(private_message_sound, { to_player = target, gain = beerchat.sounds_default_gain } )
-								end
-							else
-								minetest.chat_send_player(
-									target,
-									beerchat.format_message(
-										self_message_string, {
-											from_player = name,
-											to_player = target,
-											message = msg
-										}
-									)
-								)
-
-								if beerchat.enable_sounds then
-									minetest.sound_play(self_message_sound, { to_player = target, gain = beerchat.sounds_default_gain } )
-								end
-							end
-						end
-						atleastonesent = true
-						successplayers = successplayers..target..","
-					end
-				end
-				-- Register the chat in the target persons last spoken to table
-				atchat_lastrecv[name] = players
-				if atleastonesent then
-					successplayers = successplayers:sub(1, -2)
-					if (successplayers ~= name) then
-						minetest.chat_send_player(
-							name,
-							beerchat.format_message(
-								private_message_sent_string, {
-									to_player = successplayers,
-									message = msg
-								}
-							)
-						)
-					end
-				end
+			if players ~= "" then
+				send_pm_all(name, msg, string.gmatch(","..players..",", ",([^,]+),"))
+			elseif atchat_lastrecv[name] and #atchat_lastrecv[name] > 0 then
+				local i = 0
+				send_pm_all(name, msg, function() i = i + 1; return atchat_lastrecv[name][i] end)
 			else
 				minetest.chat_send_player(name, "You have not sent private messages to anyone yet, " ..
 					"please specify player names to send message to")
@@ -100,68 +98,11 @@ beerchat.register_on_chat_message(function(name, message)
 	end
 end)
 
-local send_pm = function(players, name, msg)
-	local atleastonesent = false
-	local successplayers = ""
-	for target in string.gmatch(","..players..",", ",([^,]+),") do
-		-- Checking if the target exists
-		if not minetest.get_player_by_name(target) then
-			minetest.chat_send_player(name, ""..target.." is not online")
-		else
-			if not beerchat.has_player_muted_player(target, name) then
-				if target ~= name then
-					-- Sending the message
-					minetest.chat_send_player(
-						target,
-						beerchat.format_message(
-							private_message_string, {
-								from_player = name,
-								message = msg
-							}
-						)
-					)
-
-					if beerchat.enable_sounds then
-						minetest.sound_play(private_message_sound, { to_player = target, gain = beerchat.sounds_default_gain } )
-					end
-				else
-					minetest.chat_send_player(
-						target,
-						beerchat.format_message(
-							self_message_string, {
-								from_player = name,
-								message = msg
-							}
-						)
-					)
-					if beerchat.enable_sounds then
-						minetest.sound_play(self_message_sound, { to_player = target, gain = beerchat.sounds_default_gain } )
-					end
-				end
-			end
-			atleastonesent = true
-			successplayers = successplayers..target..","
-		end
-	end
-	-- Register the chat in the target persons last spoken to table
-	atchat_lastrecv[name] = players
-	if atleastonesent then
-		successplayers = successplayers:sub(1, -2)
-		if (successplayers ~= name) then
-			minetest.chat_send_player(
-				name,
-				beerchat.format_message(private_message_sent_string, { to_player = successplayers, message = msg })
-			)
-		end
-	end
-
-end
-
 local msg_override = {
 	params = "<Player Name> <Message>",
 	description = "Send private message to player, "..
-				"for compatibility with the old chat command but with new style chat muting support "..
-				  "(players will not receive your message if they muted you) and multiple (comma separated) player support",
+		"for compatibility with the old chat command but with new style chat muting support "..
+		"(players will not receive your message if they muted you) and multiple (comma separated) player support",
 	func = function(name, param)
 		local msg_data = beerchat.default_on_receive(name, param)
 		if not msg_data then
@@ -179,13 +120,9 @@ local msg_override = {
 			elseif msg == "" then
 				minetest.chat_send_player(name, "ERROR: Please enter the private message you would like to send")
 				return false
-			else
-				if not beerchat.execute_callbacks('before_send_pm', name, msg, players) then
-					return false
-				end
-				if players and players ~= "" then
-					send_pm(players, name, msg)
-				end
+			elseif players and players ~= "" then
+				local targets = string.gmatch(","..players..",", ",([^,]+),")
+				send_pm_all(name, msg, targets)
 			end
 			return true
 		end

--- a/spec/plugin_pm_spec.lua
+++ b/spec/plugin_pm_spec.lua
@@ -1,0 +1,84 @@
+require("mineunit")
+
+mineunit("core")
+mineunit("player")
+mineunit("server")
+
+sourcefile("init")
+
+describe("private message", function()
+
+	local ANY = require("luassert.match")._
+
+	local SX = Player("SX", { shout = 1 })
+	local Sam = Player("Sam", { shout = 1 })
+	local Doe = Player("Doe", { shout = 1 })
+
+	setup(function()
+		mineunit:execute_on_joinplayer(SX)
+		mineunit:execute_on_joinplayer(Sam)
+		mineunit:execute_on_joinplayer(Doe)
+	end)
+
+	teardown(function()
+		mineunit:execute_on_leaveplayer(Doe)
+		mineunit:execute_on_leaveplayer(Sam)
+		mineunit:execute_on_leaveplayer(SX)
+	end)
+
+	describe("delivery", function()
+		-- Verifies that private messages are only delivered to selected recipients
+
+		it("works with @Sam", function()
+			local msg = "works with @Sam"
+			spy.on(beerchat, "send_on_channel")
+			spy.on(beerchat, "execute_callbacks")
+			spy.on(minetest, "chat_send_player")
+			SX:send_chat_message("@Sam "..msg)
+			assert.spy(beerchat.send_on_channel).was_not.called()
+			assert.spy(beerchat.execute_callbacks).was_not.called_with("before_send_pm", ANY, ANY, "Doe")
+			assert.spy(beerchat.execute_callbacks).was.called_with("before_send_pm", "SX", msg, "Sam")
+			assert.spy(minetest.chat_send_player).was.called(2)
+		end)
+
+		it("works with /pm Sam", function()
+			local msg = "works with /pm Sam"
+			spy.on(beerchat, "send_on_channel")
+			spy.on(beerchat, "execute_callbacks")
+			spy.on(minetest, "chat_send_player")
+			SX:send_chat_message("/pm Sam "..msg)
+			assert.spy(beerchat.send_on_channel).was_not.called()
+			assert.spy(beerchat.execute_callbacks).was_not.called_with("before_send_pm", ANY, ANY, "Doe")
+			assert.spy(beerchat.execute_callbacks).was.called_with("before_send_pm", "SX", msg, "Sam")
+			assert.spy(minetest.chat_send_player).was.called(2)
+		end)
+
+		it("works with @ (memory)", function()
+			local msg = "works with @ (memory)"
+			SX:send_chat_message("@Sam Initialize recipient memory")
+			spy.on(beerchat, "send_on_channel")
+			spy.on(beerchat, "execute_callbacks")
+			spy.on(minetest, "chat_send_player")
+			SX:send_chat_message("@ "..msg)
+			assert.spy(beerchat.send_on_channel).was_not.called()
+			assert.spy(beerchat.execute_callbacks).was_not.called_with("before_send_pm", ANY, ANY, "Doe")
+			assert.spy(beerchat.execute_callbacks).was.called_with("before_send_pm", "SX", msg, "Sam")
+			assert.spy(minetest.chat_send_player).was.called(2)
+		end)
+
+		it("fails with /pm NA", function()
+			local msg = "fails with /pm NA"
+			spy.on(beerchat, "send_on_channel")
+			spy.on(beerchat, "execute_callbacks")
+			spy.on(minetest, "chat_send_player")
+			SX:send_chat_message("/pm NA "..msg)
+			assert.spy(beerchat.send_on_channel).was_not.called()
+			assert.spy(beerchat.execute_callbacks).was_not.called_with("before_send_pm", ANY, ANY, "Doe")
+			assert.spy(beerchat.execute_callbacks).was_not.called_with("before_send_pm", ANY, ANY, "Sam")
+			assert.spy(beerchat.execute_callbacks).was_not.called_with("before_send_pm", ANY, ANY, "SX")
+			assert.spy(minetest.chat_send_player).was.called(1)
+		end)
+
+	end)
+
+end)

--- a/spec/plugin_whisper_spec.lua
+++ b/spec/plugin_whisper_spec.lua
@@ -112,12 +112,12 @@ describe("Whisper", function()
 		-- Send private message and record callbacks to find out execution path
 		spy.on(beerchat, "send_on_channel")
 		spy.on(beerchat, "execute_callbacks")
-		SX:send_chat_message("@SX Private message in whisper mode")
+		SX:send_chat_message("@Sam Private message in whisper mode")
 		SX:send_chat_message("SX message in whisper mode")
 
 		-- Verify that message was handled correctly
 		assert.spy(beerchat.send_on_channel).was_not.called()
-		assert.spy(beerchat.execute_callbacks).was.called_with("before_send_pm", "SX", m._, m._)
+		assert.spy(beerchat.execute_callbacks).was.called_with("before_send_pm", "SX", m._, "Sam")
 	end)
 
 end)


### PR DESCRIPTION
Closes #92 and #88 

* Moved mute commands from core to plugin and changed to events.
* Removed `before_check_muted` callback hack.
* Reworked some pm events / callbacks / generally refactored pm.
* Added `beerchat.allow_private_message(name, target)`
* Ignoring tests and ~lua, actually reduced LoC, 198 insertions(+), 241 deletions(-)
* Added and improved tests.
* Added coverage badge.