### PR TITLE
Fix mute (and remote messages)

### DIFF
--- a/plugin/mute.lua
+++ b/plugin/mute.lua
@@ -1,9 +1,9 @@
 
 local is_muted = function(name, target)
-	local player = minetest.get_player_by_name(name)
+	local player = minetest.get_player_by_name(target)
 	if player then
 		local meta = player:get_meta()
-		return meta:get("beerchat:muted:" .. target) == "true"
+		return meta:get("beerchat:muted:" .. name) == "true"
 	end
 	return true
 end

--- a/spec/relay_spec.lua
+++ b/spec/relay_spec.lua
@@ -2,8 +2,10 @@ require("mineunit")
 
 mineunit("core")
 mineunit("player")
+mineunit("common/after")
 mineunit("server")
 mineunit("http")
+mineunit("auth")
 
 -- mineunit doesn't have a stub for register_on_auth_fail, so add one
 minetest.register_on_auth_fail = function(...) end
@@ -12,11 +14,30 @@ sourcefile("init")
 
 describe("Relay", function()
 
-  it("lists available commands", function()
-    local fn = beerchat.get_relaycommand("help")
-    local out = fn()
+	-- At least one player must be in game or some message delivery loops will be skipped
+	local SX = Player("SX", { shout = 1 })
+	setup(function() mineunit:execute_on_joinplayer(SX) end)
+	teardown(function() mineunit:execute_on_leaveplayer(SX) end)
 
-    assert.has.match("Available commands:.*help", out)
-  end)
+	it("lists available commands", function()
+		local fn = beerchat.get_relaycommand("help")
+		local out = fn()
+
+		assert.has.match("Available commands:.*help", out)
+	end)
+
+	it("delivers messages to chat", function()
+		mineunit.http_server:set_response({
+			code = 200,
+			data = [[ [{
+				"username": "REMOTE-USER",
+				"text": "REMOTE MESSAGE FROM BRIDGE",
+				"gateway": "main",
+				"protocol": ""
+			}] ]]
+		})
+		mineunit:execute_globalstep(60)
+		mineunit:execute_globalstep()
+	end)
 
 end)


### PR DESCRIPTION
Mute got swapped so that it tried to check if  sender has muted recipient.
Also blocked all remote messages because there wasn't players with such names to check for mute.